### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily-batch.yml
+++ b/.github/workflows/daily-batch.yml
@@ -1,4 +1,6 @@
 name: Post to Pixela on a daily basis
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 0 * * *' # Every day at 00:00 UTC


### PR DESCRIPTION
Potential fix for [https://github.com/mahata/bsky-pixela-tracker/security/code-scanning/2](https://github.com/mahata/bsky-pixela-tracker/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs basic tasks like checking out code, setting up Python, installing dependencies, and running a script, it only requires `contents: read` permissions. This change will limit the `GITHUB_TOKEN` to the minimum necessary access, reducing the risk of unintended actions or security vulnerabilities.

The `permissions` block should be added at the root level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
